### PR TITLE
feat: Add default workout routines

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -502,14 +502,72 @@
           return Date.now().toString(36) + Math.random().toString(36).substr(2);
         };
 
+        const getDefaultWorkouts = () => {
+          return [
+            {
+              id: generateId(),
+              name: "Day 1 (Lower)",
+              exercises: [
+                { id: generateId(), name: "Leg Press", sets: 4, reps: 10 },
+                { id: generateId(), name: "RDL", sets: 4, reps: 10 },
+                { id: generateId(), name: "Leg Curl of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Calves of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Leg Extensions of Choice", sets: 3, reps: 15 },
+              ],
+            },
+            {
+              id: generateId(),
+              name: "Day 2 (Upper)",
+              exercises: [
+                { id: generateId(), name: "Horizontal Press of Choice", sets: 4, reps: 10 },
+                { id: generateId(), name: "Horizontal Row of Choice", sets: 4, reps: 12 },
+                { id: generateId(), name: "Vertical Press of Choice", sets: 4, reps: 10 },
+                { id: generateId(), name: "Vertical Pull of Choice", sets: 4, reps: 12 },
+                { id: generateId(), name: "Triceps Extension of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Biceps of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Lateral Raise of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Rear Delt of Choice", sets: 3, reps: 15 },
+              ],
+            },
+            {
+              id: generateId(),
+              name: "Day 3 (Lower)",
+              exercises: [
+                { id: generateId(), name: "Squat Type Movement of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Hip Hinge Type Movement of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Leg Curl of Choice", sets: 2, reps: 20 },
+                { id: generateId(), name: "Calves of Choice", sets: 2, reps: 20 },
+                { id: generateId(), name: "Leg Extensions of Choice", sets: 2, reps: 20 },
+              ],
+            },
+            {
+              id: generateId(),
+              name: "Day 4 (Upper)",
+              exercises: [
+                { id: generateId(), name: "Horizontal Press of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Horizontal Row of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Vertical Press of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Vertical Pull of Choice", sets: 3, reps: 15 },
+                { id: generateId(), name: "Triceps Extension of Choice", sets: 2, reps: 20 },
+                { id: generateId(), name: "Biceps of Choice", sets: 2, reps: 20 },
+                { id: generateId(), name: "Lateral Raise of Choice", sets: 2, reps: 20 },
+                { id: generateId(), name: "Rear Delt of Choice", sets: 2, reps: 20 },
+              ],
+            },
+          ];
+        };
+
         const saveWorkouts = () => {
           localStorage.setItem("workouts", JSON.stringify(workouts));
         };
 
         const loadWorkouts = () => {
           const saved = localStorage.getItem("workouts");
-          if (saved) {
+          if (saved && JSON.parse(saved).length > 0) {
             workouts = JSON.parse(saved);
+          } else {
+            workouts = getDefaultWorkouts();
+            saveWorkouts();
           }
           updateWorkoutSelect();
           renderWorkoutsList();


### PR DESCRIPTION
This change introduces a set of default workout routines to the application. These routines are automatically loaded if no existing workouts are found in the user's local storage, providing a better onboarding experience for new users.

The default workouts are based on a 4-day upper/lower split, with predefined exercises, sets, and reps.