### PR TITLE
🧪 [testing improvement] Add UserProfile tests

### DIFF
--- a/components/layout/UserProfile.tsx
+++ b/components/layout/UserProfile.tsx
@@ -26,6 +26,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
       <StyledView className="flex-row items-center space-x-4">
         {user.photoURL && (
           <Image
+            testID="user-profile-image"
             source={{ uri: user.photoURL }}
             style={{ width: 48, height: 48, borderRadius: 24 }}
           />
@@ -40,6 +41,7 @@ const UserProfile: React.FC<UserProfileProps> = ({
         </StyledView>
       </StyledView>
       <StyledTouchableOpacity
+        testID="disconnect-account-button"
         onPress={disconnectAccount}
         className="p-3 bg-red-600 rounded-lg">
         <LogOut color="white" size={24} />

--- a/components/layout/__tests__/UserProfile.test.tsx
+++ b/components/layout/__tests__/UserProfile.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import UserProfile from '../UserProfile';
+import type { User as FirebaseUser } from 'firebase/auth';
+
+describe('UserProfile', () => {
+  const mockDisconnectAccount = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const mockUser: Partial<FirebaseUser> = {
+    displayName: 'Test User',
+    email: 'test@example.com',
+    photoURL: 'https://example.com/photo.jpg',
+  };
+
+  it('renders null when no user is provided', () => {
+    const { toJSON } = render(
+      <UserProfile user={null} disconnectAccount={mockDisconnectAccount} />
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders user details correctly', () => {
+    const { getByText, getByTestId } = render(
+      <UserProfile user={mockUser as FirebaseUser} disconnectAccount={mockDisconnectAccount} />
+    );
+
+    expect(getByText('Test User')).toBeTruthy();
+    expect(getByText('test@example.com')).toBeTruthy();
+
+    const image = getByTestId('user-profile-image');
+    expect(image.props.source.uri).toBe('https://example.com/photo.jpg');
+  });
+
+  it('renders correctly without photoURL', () => {
+    const userWithoutPhoto = { ...mockUser, photoURL: null };
+    const { queryByTestId } = render(
+      <UserProfile user={userWithoutPhoto as unknown as FirebaseUser} disconnectAccount={mockDisconnectAccount} />
+    );
+
+    expect(queryByTestId('user-profile-image')).toBeNull();
+  });
+
+  it('calls disconnectAccount when logout button is pressed', () => {
+    const { getByTestId } = render(
+      <UserProfile user={mockUser as FirebaseUser} disconnectAccount={mockDisconnectAccount} />
+    );
+
+    const button = getByTestId('disconnect-account-button');
+    fireEvent.press(button);
+
+    expect(mockDisconnectAccount).toHaveBeenCalledTimes(1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4784,11 +4784,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -6176,10 +6171,10 @@ lighthouse-logger@^1.0.0:
     debug "^2.6.9"
     marky "^1.2.2"
 
-lightningcss-darwin-arm64@1.30.2:
+lightningcss-linux-x64-gnu@1.30.2:
   version "1.30.2"
-  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz"
-  integrity sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==
+  resolved "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz"
+  integrity sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==
 
 lightningcss@^1.30.1:
   version "1.30.2"


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `UserProfile` component was lacking tests, specifically around rendering conditions (whether user exists, rendering user info, checking photo URL, clicking disconnect account button).

📊 **Coverage:** What scenarios are now tested
1. Component renders `null` when no user is provided.
2. User details (displayName, email) and image correctly render when user is populated.
3. Proper fallback mapping when a user is provided but without a photo URL.
4. Calling `disconnectAccount` prop functionality when the "Logout" button is pressed.

✨ **Result:** The improvement in test coverage
We now have comprehensive test coverage for `UserProfile` component layout rendering and interactibility.

---
*PR created automatically by Jules for task [4430438812090506007](https://jules.google.com/task/4430438812090506007) started by @ganganimaulik*