### PR TITLE
🧹 Remove unused console.log in useAuth

### DIFF
--- a/hooks/__tests__/useAuth.test.ts
+++ b/hooks/__tests__/useAuth.test.ts
@@ -107,9 +107,7 @@ describe('useAuth Hook', () => {
 
     expect(result.current.isSigningIn).toBe(false)
     expect(signInWithCredential).not.toHaveBeenCalled()
-    expect(consoleLogSpy).toHaveBeenCalledWith(
-      'User cancelled the Google Sign-In flow.',
-    )
+    expect(consoleLogSpy).not.toHaveBeenCalled()
     consoleLogSpy.mockRestore()
   })
 

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -76,7 +76,6 @@ export const useAuth = (onAuthSuccess: OnAuthSuccessCallback): AuthHook => {
       // Known error codes for user cancellation
       const gError = error as { code?: string }
       if (gError.code === '12501' || gError.code === 'SIGN_IN_CANCELLED') {
-        console.log('User cancelled the Google Sign-In flow.')
       } else {
         console.error('Google Sign-In error:', error)
       }


### PR DESCRIPTION
🎯 **What:** Removed the `console.log` statement that logs when a user cancels the Google Sign-in flow.
💡 **Why:** It's an unnecessary log in a catch block that makes noise during normal usage when users naturally cancel the flow. It does not provide any real diagnostic value.
✅ **Verification:** Verified tests run and pass without it. Also updated the unit test `hooks/__tests__/useAuth.test.ts` to expect no console logging on cancellation.
✨ **Result:** A slightly cleaner file and less spam in development console.

---
*PR created automatically by Jules for task [8560016346942093002](https://jules.google.com/task/8560016346942093002) started by @ganganimaulik*