### PR TITLE
🧪 test: add tests for cssImport

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
     'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|@firebase|firebase)',
   ],
   setupFilesAfterEnv: ['./jest.setup.js'],
+  moduleNameMapper: {
+    '\\.css$': '<rootDir>/__mocks__/styleMock.js',
+  },
 }

--- a/utils/__tests__/cssImport.test.ts
+++ b/utils/__tests__/cssImport.test.ts
@@ -1,0 +1,8 @@
+import { importGlobalCSS } from '../cssImport';
+
+describe('importGlobalCSS (native)', () => {
+  it('should be a function that returns void', () => {
+    expect(typeof importGlobalCSS).toBe('function');
+    expect(importGlobalCSS()).toBeUndefined();
+  });
+});

--- a/utils/__tests__/cssImport.web.test.ts
+++ b/utils/__tests__/cssImport.web.test.ts
@@ -1,0 +1,8 @@
+import { importGlobalCSS } from '../cssImport.web';
+
+describe('importGlobalCSS (web)', () => {
+  it('should be a function that returns void', () => {
+    expect(typeof importGlobalCSS).toBe('function');
+    expect(importGlobalCSS()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for `utils/cssImport.ts` and `utils/cssImport.web.ts`.
📊 **Coverage:** The scenarios now tested are the proper execution and return values of `importGlobalCSS` in both the native and web contexts.
✨ **Result:** The improvement in test coverage is that `cssImport.ts` and `cssImport.web.ts` are now fully tested. Additionally, Jest configuration was updated to mock CSS imports.

---
*PR created automatically by Jules for task [2009872956185057246](https://jules.google.com/task/2009872956185057246) started by @ganganimaulik*