### PR TITLE
🧹 Remove unused dead code from ProgressScreen

### DIFF
--- a/components/ProgressScreen.tsx
+++ b/components/ProgressScreen.tsx
@@ -11,7 +11,6 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  StyleSheet,
   Alert,
 } from 'react-native'
 import { styled } from 'nativewind'
@@ -19,10 +18,7 @@ import {
   Flame,
   Trophy,
   TrendingUp,
-  Scale,
   Trash2,
-  Pencil,
-  Activity,
 } from 'lucide-react-native'
 import { LineChart } from 'react-native-chart-kit'
 import { Picker } from '@react-native-picker/picker'
@@ -280,13 +276,6 @@ const ProgressScreen: React.FC<ProgressScreenProps> = ({
     setCalorieInput('')
   }
 
-  const formatChartDate = (date: Date): string => {
-    return date.toLocaleDateString(undefined, {
-      month: 'numeric',
-      day: 'numeric',
-    })
-  }
-
   const formatDate = (date: Date): string => {
     return date.toLocaleDateString(undefined, {
       month: 'short',
@@ -325,30 +314,6 @@ const ProgressScreen: React.FC<ProgressScreenProps> = ({
     }),
     [exerciseTrends],
   )
-
-  const weightChartData = useMemo(() => {
-    const reversed = [...weightLogs].reverse().slice(-7)
-    return {
-      labels: reversed.map((log) => formatChartDate(log.date.toDate())),
-      datasets: [
-        {
-          data: reversed.map((log) => log.weight),
-        },
-      ],
-    }
-  }, [weightLogs])
-
-  const calorieChartData = useMemo(() => {
-    const reversed = [...calorieLogs].reverse().slice(-7)
-    return {
-      labels: reversed.map((log) => formatChartDate(log.date.toDate())),
-      datasets: [
-        {
-          data: reversed.map((log) => log.calories),
-        },
-      ],
-    }
-  }, [calorieLogs])
 
   if (!visible) return null
 


### PR DESCRIPTION
🎯 **What:** Removed unused `calorieChartData`, `weightChartData`, `formatChartDate`, and several unused lucide-react-native/react-native imports from `components/ProgressScreen.tsx`.

💡 **Why:** To improve codebase maintainability and readability by eliminating dead code and unused imports that were no longer referenced by the component's JSX.

✅ **Verification:** Verified changes through running `npm run lint` and the relevant parts of the full test suite (`npm run test`). Reverted some unintended package.json/yarn.lock modifications that happened during my initial test setup.

✨ **Result:** Improved maintainability and readability of `components/ProgressScreen.tsx` without changing behavior.

---
*PR created automatically by Jules for task [14541015223972327667](https://jules.google.com/task/14541015223972327667) started by @ganganimaulik*